### PR TITLE
correct name of linkify dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Turns [Noddity](http://noddity.com) post objects into basic [abstract syntax tre
 
 ```js
 var parser = require('noddity-template-parser')
-var Linkify = require('linkify')
+var Linkify = require('noddity-linkify')
 
 var linkify = Linkify('#/prefix')
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Turns [Noddity](http://noddity.com) post objects into basic [abstract syntax tre
 
 ```js
 var parser = require('noddity-template-parser')
-var Linkify = require('noddity-linkify')
+var Linkify = require('noddity-linkifier')
 
 var linkify = Linkify('#/prefix')
 


### PR DESCRIPTION
That was confusing, apparently `linkify` is an actual module!